### PR TITLE
a .gitignore which ignores cache/, output/, and pelicanconf.pyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+cache/
+output/
+pelicanconf.pyc


### PR DESCRIPTION
As I finally managed to get pelican to work I feel the need for a .gitignore to avoid a mistake. Please feel free to ignore the pull request and point me to a better way to run pelican (I just use `pelican` in the project root).
